### PR TITLE
[fix] Client: getDataForComp Parameteranpassung

### DIFF
--- a/src/main/java/github/weichware10/analyse/Client.java
+++ b/src/main/java/github/weichware10/analyse/Client.java
@@ -94,7 +94,7 @@ public class Client {
      *         wurden;
      *         false, falls benötigte Daten zum Vergleich nicht gefunden wurden
      */
-    public boolean getDataForComp(DateTime start, DateTime end) {
+    public boolean getDataForComp(DateTime start, DateTime end, ToolType dataType) {
         if (start.isAfter(end) || start.isAfter(DateTime.now()) || end.isAfter(DateTime.now())) {
             return false;
         }

--- a/src/test/java/github/weichware10/analyse/ClientTest.java
+++ b/src/test/java/github/weichware10/analyse/ClientTest.java
@@ -123,44 +123,44 @@ public class ClientTest {
         Client client1 = new Client();
         assertTrue("getDataForComp sollte True zurückgeben", client1.getDataForComp(
                 new DateTime(2021, 11, 28, 16, 0, 0),
-                new DateTime(2021, 11, 28, 19, 0, 0)));
+                new DateTime(2021, 11, 28, 19, 0, 0), ToolType.ZOOMMAPS));
 
         Client client2 = new Client();
         assertTrue("getDataForComp sollte True zurückgeben", client2.getDataForComp(
                 new DateTime(2021, 11, 28, 15, 0, 0),
-                new DateTime(2021, 11, 28, 18, 0, 0)));
+                new DateTime(2021, 11, 28, 18, 0, 0), ToolType.EYETRACKING));
 
         Client client3 = new Client();
         assertTrue("getDataForComp sollte True zurückgeben", client3.getDataForComp(
                 new DateTime(2021, 11, 28, 19, 0, 0),
-                new DateTime(2021, 11, 28, 20, 0, 0)));
+                new DateTime(2021, 11, 28, 20, 0, 0), ToolType.CODECHARTS));
 
         // * Falsche Zeiteingabe
         Client client7 = new Client();
         assertFalse("getDataForComp sollte False zurückgeben", client7.getDataForComp(
                 new DateTime(2021, 11, 28, 18, 0, 0),
-                new DateTime(2021, 11, 28, 17, 0, 0)));
+                new DateTime(2021, 11, 28, 17, 0, 0), ToolType.ZOOMMAPS));
 
         Client client8 = new Client();
         assertFalse("getDataForComp sollte False zurückgeben", client8.getDataForComp(
                 new DateTime(2021, 11, 28, 18, 0, 0),
-                new DateTime(2021, 11, 28, 17, 0, 0)));
+                new DateTime(2021, 11, 28, 17, 0, 0), ToolType.EYETRACKING));
 
         Client client9 = new Client();
         assertFalse("getDataForComp sollte False zurückgeben", client9.getDataForComp(
                 new DateTime(2021, 11, 28, 18, 0, 0),
-                new DateTime(2021, 11, 28, 17, 0, 0)));
+                new DateTime(2021, 11, 28, 17, 0, 0), ToolType.CODECHARTS));
 
         // * Zeitpunkt in der Zunkunft
         Client client10 = new Client();
         assertFalse("getDataForComp sollte False zurückgeben", client10.getDataForComp(
                 new DateTime(2021, 11, 28, 18, 0, 0),
-                DateTime.now().plusMinutes(5)));
+                DateTime.now().plusMinutes(5), ToolType.ZOOMMAPS));
 
         Client client11 = new Client();
         assertFalse("getDataForComp sollte False zurückgeben", client11.getDataForComp(
                 DateTime.now().plusMinutes(5),
-                DateTime.now().plusMinutes(10)));
+                DateTime.now().plusMinutes(10), ToolType.EYETRACKING));
     }
 
     // ? Woher kommen Daten für den Export?


### PR DESCRIPTION
Die Methode `getDataForComp()` in der Klasse `Client` vom AnalyseClient benötigt jetzt auch neben Start- und Endzeitpunkt den `ToolType` der gewollten Daten für den Vergleich für `COMPHEATMAP`